### PR TITLE
'xcdebugger/'を無視する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 #
+xcdebugger/


### PR DESCRIPTION
# 対応内容
1. 'xcdebugger/'を無視する様に、`.gitignore`ファイルを修正した。